### PR TITLE
Add recent commands to Home and quick access shelf

### DIFF
--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Commands/MainListPage.cs
@@ -57,13 +57,17 @@ public sealed partial class MainListPage : DynamicListPage,
     // Stable separator instances so that the VM cache and InPlaceUpdateList
     // recognise them across successive GetItems() calls
     private readonly Separator _pinnedSeparator = new(Resources.home_sections_pinned_title);
+    private readonly Separator _recentSeparator = new(Resources.home_sections_recent_title);
     private readonly Separator _resultsSeparator = new(Resources.results);
     private readonly Separator _fallbacksSeparator = new(Resources.fallbacks);
     private readonly Separator _commandsSeparator = new(Resources.home_sections_commands_title);
 
-    private TopLevelViewModel[]? _cachedPinnedViewModels;
-    private TopLevelViewModel[]? _cachedRegularViewModels;
+    private IListItem[]? _cachedPinnedViewModels;
+    private IListItem[]? _cachedRecentViewModels;
+    private IListItem[]? _cachedRegularViewModels;
     private bool _defaultViewDirty = true;
+    private volatile RecentCommandsManager _recentCommands;
+    private HomeRecentCommandsPlacement _recentCommandsOnHome;
 
     private RoScored<IListItem>[]? _filteredItems;
     private RoScored<IListItem>[]? _filteredApps;
@@ -121,6 +125,7 @@ public sealed partial class MainListPage : DynamicListPage,
         _settingsService = settingsService;
         _aliasManager = aliasManager;
         _appStateService = appStateService;
+        _recentCommands = _appStateService.State.RecentCommands;
         _tlcManager = topLevelCommandManager;
         _fuzzyMatcherProvider = fuzzyMatcherProvider;
         _scoringFunction = (in query, item) => ScoreTopLevelItem(in query, item, _appStateService.State.RecentCommands, _fuzzyMatcherProvider.Current, ResolveProviderSearchWeight);
@@ -165,6 +170,7 @@ public sealed partial class MainListPage : DynamicListPage,
             RaiseItemsChangedThrottle);
 
         _fallbackUpdateManager = new FallbackUpdateManager(() => RequestRefresh(fullRefresh: false));
+        _appStateService.StateChanged += AppStateService_StateChanged;
 
         // The all apps page will kick off a BG thread to start loading apps.
         // We just want to know when it is done.
@@ -194,6 +200,11 @@ public sealed partial class MainListPage : DynamicListPage,
         if (e.PropertyName == nameof(AllAppsCommandProvider.Page.IsLoading))
         {
             IsLoading = ActuallyLoading();
+            if (!AllAppsCommandProvider.Page.IsLoading && _recentCommandsOnHome != HomeRecentCommandsPlacement.Hidden)
+            {
+                _defaultViewDirty = true;
+                RequestRefresh(fullRefresh: false);
+            }
         }
     }
 
@@ -213,6 +224,21 @@ public sealed partial class MainListPage : DynamicListPage,
         }
         else
         {
+            RequestRefresh(fullRefresh: false);
+        }
+    }
+
+    private void AppStateService_StateChanged(IAppStateService sender, AppStateModel args)
+    {
+        if (ReferenceEquals(_recentCommands, args.RecentCommands))
+        {
+            return;
+        }
+
+        _recentCommands = args.RecentCommands;
+        if (_recentCommandsOnHome != HomeRecentCommandsPlacement.Hidden)
+        {
+            _defaultViewDirty = true;
             RequestRefresh(fullRefresh: false);
         }
     }
@@ -274,9 +300,14 @@ public sealed partial class MainListPage : DynamicListPage,
 
     public override IListItem[] GetItems()
     {
+        if (string.IsNullOrWhiteSpace(SearchText))
+        {
+            return GetDefaultViewItems();
+        }
+
         lock (_tlcManager.TopLevelCommands)
         {
-            return string.IsNullOrWhiteSpace(SearchText) ? GetDefaultViewItems() : GetSearchViewItems();
+            return GetSearchViewItems();
         }
     }
 
@@ -411,70 +442,78 @@ public sealed partial class MainListPage : DynamicListPage,
         }
 
         var pinned = _cachedPinnedViewModels!;
+        var recent = _cachedRecentViewModels!;
         var regular = _cachedRegularViewModels!;
         var pinnedCount = pinned.Length;
+        var recentCount = recent.Length;
         var regularCount = regular.Length;
 
-        var sectionCount = (pinnedCount > 0 ? 1 : 0) + (regularCount > 0 ? 1 : 0);
+        var sectionCount =
+            (pinnedCount > 0 ? 1 : 0) +
+            (recentCount > 0 ? 1 : 0) +
+            (regularCount > 0 ? 1 : 0);
         if (sectionCount == 0)
         {
             return [];
         }
 
-        var result = new IListItem[pinnedCount + regularCount + sectionCount];
+        var result = new IListItem[pinnedCount + recentCount + regularCount + sectionCount];
         var writeIndex = 0;
-        if (pinnedCount > 0)
+
+        void AppendSection(Separator separator, IListItem[] items)
         {
-            result[writeIndex++] = _pinnedSeparator;
-            Array.Copy(pinned, 0, result, writeIndex, pinnedCount);
-            writeIndex += pinnedCount;
+            if (items.Length == 0)
+            {
+                return;
+            }
+
+            result[writeIndex++] = separator;
+            Array.Copy(items, 0, result, writeIndex, items.Length);
+            writeIndex += items.Length;
         }
 
-        if (regularCount > 0)
+        if (_recentCommandsOnHome == HomeRecentCommandsPlacement.BeforePinned)
         {
-            result[writeIndex++] = _commandsSeparator;
-            Array.Copy(regular, 0, result, writeIndex, regularCount);
+            AppendSection(_recentSeparator, recent);
+            AppendSection(_pinnedSeparator, pinned);
         }
+        else
+        {
+            AppendSection(_pinnedSeparator, pinned);
+            AppendSection(_recentSeparator, recent);
+        }
+
+        AppendSection(_commandsSeparator, regular);
 
         return result;
     }
 
     private void RebuildDefaultViewCache()
     {
-        var allCommands = _tlcManager.TopLevelCommands;
-        var pinnedSettings = _tlcManager.PinnedCommands;
-
-        // Resolve pinned VMs in settings order
-        var pinned = new List<TopLevelViewModel>(pinnedSettings.Count);
-        for (var i = 0; i < pinnedSettings.Count; i++)
+        PinnedCommandSettings[] pinnedSettings;
+        lock (_tlcManager.PinnedCommands)
         {
-            var s = pinnedSettings[i];
-            for (var j = 0; j < allCommands.Count; j++)
-            {
-                var cmd = allCommands[j];
-                if (TopLevelCommandEligibility.IsEligibleForHome(cmd) &&
-                    cmd.CommandProviderId == s.ProviderId &&
-                    cmd.Id == s.CommandId)
-                {
-                    pinned.Add(cmd);
-                    break;
-                }
-            }
+            pinnedSettings = [.. _tlcManager.PinnedCommands];
         }
 
-        // Single pass for regular items
-        var regular = new List<TopLevelViewModel>(allCommands.Count);
-        for (var i = 0; i < allCommands.Count; i++)
+        TopLevelViewModel[] allCommands;
+        lock (_tlcManager.TopLevelCommands)
         {
-            var candidate = allCommands[i];
-            if (TopLevelCommandEligibility.IsEligibleForHome(candidate) && !_tlcManager.IsPinned(candidate.CommandProviderId, candidate.Id))
-            {
-                regular.Add(candidate);
-            }
+            allCommands = [.. _tlcManager.TopLevelCommands];
         }
 
-        _cachedPinnedViewModels = [.. pinned];
-        _cachedRegularViewModels = [.. regular];
+        IEnumerable<string> recentCommandIds = _recentCommandsOnHome == HomeRecentCommandsPlacement.Hidden
+            ? []
+            : _recentCommands.EnumerateRecentCommandIds();
+        var sections = TopLevelCommandResolver.Resolve(
+            pinnedSettings,
+            recentCommandIds,
+            allCommands,
+            includeApps: _includeApps);
+
+        _cachedPinnedViewModels = [.. sections.Pinned];
+        _cachedRecentViewModels = [.. sections.Recent];
+        _cachedRegularViewModels = [.. sections.Regular];
         _defaultViewDirty = false;
     }
 
@@ -1017,6 +1056,13 @@ public sealed partial class MainListPage : DynamicListPage,
     {
         ShowDetails = settings.ShowAppDetails;
 
+        if (_recentCommandsOnHome != settings.RecentCommandsOnHome)
+        {
+            _recentCommandsOnHome = settings.RecentCommandsOnHome;
+            _defaultViewDirty = true;
+            RequestRefresh(fullRefresh: false);
+        }
+
         // A per-provider search-weight change has to reorder the query that is already on screen.
         // Scoring reads the weight live, but scored results are cached, so without an explicit
         // re-score the active query keeps its old order until the next keystroke. Detect a weight
@@ -1083,6 +1129,7 @@ public sealed partial class MainListPage : DynamicListPage,
         _tlcManager.PropertyChanged -= TlcManager_PropertyChanged;
         _tlcManager.TopLevelCommands.CollectionChanged -= Commands_CollectionChanged;
         _tlcManager.PinnedCommands.CollectionChanged -= PinnedCommands_CollectionChanged;
+        _appStateService.StateChanged -= AppStateService_StateChanged;
 
         AllAppsCommandProvider.Page.PropChanged -= AllApps_PropChanged;
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.Designer.cs
@@ -1184,6 +1184,15 @@ namespace Microsoft.CmdPal.UI.ViewModels.Properties {
                 return ResourceManager.GetString("home_sections_pinned_title", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Recent.
+        /// </summary>
+        public static string home_sections_recent_title {
+            get {
+                return ResourceManager.GetString("home_sections_recent_title", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Pinned.

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/Properties/Resources.resx
@@ -322,6 +322,9 @@
   <data name="home_sections_pinned_title" xml:space="preserve">
     <value>Pinned</value>
   </data>
+  <data name="home_sections_recent_title" xml:space="preserve">
+    <value>Recent</value>
+  </data>
   <data name="home_sections_commands_title" xml:space="preserve">
     <value>Commands</value>
   </data>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfItem.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfItem.cs
@@ -2,22 +2,75 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
+using Microsoft.CmdPal.UI.ViewModels.Messages;
+using Microsoft.CmdPal.UI.ViewModels.Models;
+using Microsoft.CommandPalette.Extensions;
+
 namespace Microsoft.CmdPal.UI.ViewModels;
 
-public sealed class QuickAccessShelfItem(TopLevelViewModel command, int index) : IEquatable<QuickAccessShelfItem>
+public sealed class QuickAccessShelfItem : IEquatable<QuickAccessShelfItem>
 {
-    public TopLevelViewModel Command { get; } = command;
+    private readonly IListItem _item;
+    private readonly object? _sourceIcon;
+    private readonly int _shortcutIndex;
 
-    public int Index { get; } = index;
+    public string Title { get; }
 
-    public string ShortcutDigit => QuickAccessShelfResolver.IndexToShortcutDigit(Index);
+    public IconInfoViewModel Icon { get; }
+
+    public string ProviderId { get; }
+
+    public string CommandId { get; }
+
+    public bool StartsRecentSection { get; }
+
+    public string ShortcutDigit => QuickAccessShelfResolver.IndexToShortcutDigit(_shortcutIndex);
+
+    public QuickAccessShelfItem(IListItem item, int shortcutIndex, bool startsRecentSection)
+    {
+        _item = item;
+        Title = item.Title;
+        _shortcutIndex = shortcutIndex;
+        StartsRecentSection = startsRecentSection;
+        ProviderId = TopLevelCommandResolver.GetProviderId(item);
+        CommandId = TopLevelCommandResolver.GetCommandId(item);
+
+        if (item is TopLevelViewModel topLevel)
+        {
+            Icon = topLevel.IconViewModel;
+            _sourceIcon = Icon;
+        }
+        else
+        {
+            var sourceIcon = item.Icon;
+            _sourceIcon = sourceIcon;
+            Icon = new IconInfoViewModel(sourceIcon);
+            Icon.InitializeProperties();
+        }
+    }
+
+    public PerformCommandMessage GetPerformCommandMessage()
+    {
+        if (_item is TopLevelViewModel topLevel)
+        {
+            return topLevel.GetPerformCommandMessage();
+        }
+
+        var command = _item.Command ?? throw new InvalidOperationException("Quick-access items must have a command");
+        return new PerformCommandMessage(
+            new ExtensionObject<ICommand>(command),
+            new ExtensionObject<IListItem>(_item));
+    }
 
     public bool Equals(QuickAccessShelfItem? other) =>
         other is not null &&
-        ReferenceEquals(Command, other.Command) &&
-        Index == other.Index;
+        ReferenceEquals(_item, other._item) &&
+        ReferenceEquals(_sourceIcon, other._sourceIcon) &&
+        string.Equals(Title, other.Title, StringComparison.Ordinal) &&
+        _shortcutIndex == other._shortcutIndex &&
+        StartsRecentSection == other.StartsRecentSection;
 
     public override bool Equals(object? obj) => Equals(obj as QuickAccessShelfItem);
 
-    public override int GetHashCode() => HashCode.Combine(Command, Index);
+    public override int GetHashCode() => HashCode.Combine(_item, _sourceIcon, Title, _shortcutIndex, StartsRecentSection);
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfResolver.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfResolver.cs
@@ -6,35 +6,6 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 
 internal static class QuickAccessShelfResolver
 {
-    internal static IReadOnlyList<TCommand> Resolve<TCommand>(
-        IEnumerable<PinnedCommandSettings> pinnedCommands,
-        IEnumerable<TCommand> availableCommands,
-        Func<TCommand, string> providerIdSelector,
-        Func<TCommand, string> commandIdSelector,
-        Func<TCommand, bool> isEligible)
-        where TCommand : class
-    {
-        var commandsById = new Dictionary<(string ProviderId, string CommandId), TCommand>();
-        foreach (var command in availableCommands)
-        {
-            if (isEligible(command))
-            {
-                commandsById.TryAdd((providerIdSelector(command), commandIdSelector(command)), command);
-            }
-        }
-
-        var resolvedCommands = new List<TCommand>();
-        foreach (var pinnedCommand in pinnedCommands)
-        {
-            if (commandsById.TryGetValue((pinnedCommand.ProviderId, pinnedCommand.CommandId), out var command))
-            {
-                resolvedCommands.Add(command);
-            }
-        }
-
-        return resolvedCommands;
-    }
-
     internal static string IndexToShortcutDigit(int index)
     {
         return index switch

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/QuickAccessShelfViewModel.cs
@@ -5,6 +5,9 @@
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using CommunityToolkit.Mvvm.ComponentModel;
+using Microsoft.CmdPal.Ext.Apps;
+using Microsoft.CmdPal.UI.ViewModels.Services;
+using Microsoft.CommandPalette.Extensions;
 using Microsoft.CommandPalette.Extensions.Toolkit;
 
 namespace Microsoft.CmdPal.UI.ViewModels;
@@ -12,17 +15,30 @@ namespace Microsoft.CmdPal.UI.ViewModels;
 public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDisposable
 {
     private readonly TopLevelCommandManager _topLevelCommandManager;
+    private readonly IAppStateService _appStateService;
     private readonly TaskScheduler _scheduler;
+    private readonly List<INotifyPropChanged> _observedItems = [];
+    private volatile RecentCommandsManager _recentCommands;
+    private volatile bool _includeRecentCommands;
     private volatile bool _isDisposed;
     private int _rebuildQueued;
     private int _visibleCapacity = int.MaxValue;
 
-    public QuickAccessShelfViewModel(TopLevelCommandManager topLevelCommandManager, TaskScheduler scheduler)
+    public QuickAccessShelfViewModel(
+        TopLevelCommandManager topLevelCommandManager,
+        IAppStateService appStateService,
+        bool includeRecentCommands,
+        TaskScheduler scheduler)
     {
         _topLevelCommandManager = topLevelCommandManager;
+        _appStateService = appStateService;
+        _recentCommands = _appStateService.State.RecentCommands;
+        _includeRecentCommands = includeRecentCommands;
         _scheduler = scheduler;
         _topLevelCommandManager.PinnedCommands.CollectionChanged += Commands_CollectionChanged;
         _topLevelCommandManager.TopLevelCommands.CollectionChanged += Commands_CollectionChanged;
+        _appStateService.StateChanged += AppStateService_StateChanged;
+        AllAppsCommandProvider.Page.PropChanged += AllApps_PropChanged;
         RebuildItems();
     }
 
@@ -39,6 +55,17 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
     public int ItemCount => Items.Count;
 
     public int VisibleItemCount => VisibleItems.Count;
+
+    public void SetIncludeRecentCommands(bool includeRecentCommands)
+    {
+        if (_includeRecentCommands == includeRecentCommands)
+        {
+            return;
+        }
+
+        _includeRecentCommands = includeRecentCommands;
+        QueueRebuild();
+    }
 
     public void SetVisibleCapacity(int capacity)
     {
@@ -60,6 +87,38 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
     private void Commands_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
         QueueRebuild();
+    }
+
+    private void AppStateService_StateChanged(IAppStateService sender, AppStateModel args)
+    {
+        if (ReferenceEquals(_recentCommands, args.RecentCommands))
+        {
+            return;
+        }
+
+        _recentCommands = args.RecentCommands;
+        if (_includeRecentCommands)
+        {
+            QueueRebuild();
+        }
+    }
+
+    private void AllApps_PropChanged(object? sender, IPropChangedEventArgs args)
+    {
+        if (_includeRecentCommands &&
+            args.PropertyName == nameof(AllAppsCommandProvider.Page.IsLoading) &&
+            !AllAppsCommandProvider.Page.IsLoading)
+        {
+            QueueRebuild();
+        }
+    }
+
+    private void ObservedItem_PropChanged(object? sender, IPropChangedEventArgs args)
+    {
+        if (args.PropertyName is nameof(IListItem.Title) or nameof(IListItem.Icon))
+        {
+            QueueRebuild();
+        }
     }
 
     private void QueueRebuild()
@@ -100,14 +159,25 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
             availableCommands = [.. _topLevelCommandManager.TopLevelCommands];
         }
 
-        var resolvedCommands = QuickAccessShelfResolver.Resolve(
+        IEnumerable<string> recentCommandIds = _includeRecentCommands
+            ? _recentCommands.EnumerateRecentCommandIds()
+            : [];
+        var sections = TopLevelCommandResolver.Resolve(
             pinnedCommands,
+            recentCommandIds,
             availableCommands,
-            static command => command.CommandProviderId,
-            static command => command.Id,
-            TopLevelCommandEligibility.IsEligibleForHome);
+            includeApps: _includeRecentCommands && _topLevelCommandManager.IsProviderActive(AllAppsCommandProvider.WellKnownId),
+            includeRegular: false);
 
-        var shelfItems = resolvedCommands.Select((command, index) => new QuickAccessShelfItem(command, index));
+        UpdateObservedItems(sections.Pinned.Concat(sections.Recent));
+
+        var shelfItems = sections.Pinned.Select(
+            (command, index) => new QuickAccessShelfItem(command, index, startsRecentSection: false))
+            .Concat(sections.Recent.Select(
+                (command, index) => new QuickAccessShelfItem(
+                    command,
+                    shortcutIndex: -1,
+                    startsRecentSection: index == 0 && sections.Pinned.Count > 0)));
         ListHelpers.InPlaceUpdateList(Items, shelfItems);
         RepartitionItems();
 
@@ -119,6 +189,24 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
         if (previousItemCount != ItemCount)
         {
             OnPropertyChanged(nameof(ItemCount));
+        }
+    }
+
+    private void UpdateObservedItems(IEnumerable<IListItem> items)
+    {
+        foreach (var item in _observedItems)
+        {
+            item.PropChanged -= ObservedItem_PropChanged;
+        }
+
+        _observedItems.Clear();
+        foreach (var item in items)
+        {
+            if (item is INotifyPropChanged observable)
+            {
+                observable.PropChanged += ObservedItem_PropChanged;
+                _observedItems.Add(observable);
+            }
         }
     }
 
@@ -152,6 +240,9 @@ public sealed partial class QuickAccessShelfViewModel : ObservableObject, IDispo
         _isDisposed = true;
         _topLevelCommandManager.PinnedCommands.CollectionChanged -= Commands_CollectionChanged;
         _topLevelCommandManager.TopLevelCommands.CollectionChanged -= Commands_CollectionChanged;
+        _appStateService.StateChanged -= AppStateService_StateChanged;
+        AllAppsCommandProvider.Page.PropChanged -= AllApps_PropChanged;
+        UpdateObservedItems([]);
         GC.SuppressFinalize(this);
     }
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/RecentCommandsManager.cs
@@ -106,6 +106,18 @@ public record RecentCommandsManager : IRecentCommandsManager
     /// </summary>
     public void PrewarmIndex() => _ = Index;
 
+    /// <summary>
+    /// Enumerates command ids from most recently used to least recently used without copying the
+    /// persisted history. Consumers can stop as soon as they have resolved enough visible items.
+    /// </summary>
+    public IEnumerable<string> EnumerateRecentCommandIds()
+    {
+        foreach (var item in History)
+        {
+            yield return item.CommandId;
+        }
+    }
+
     public int GetCommandHistoryWeight(string commandId)
         => GetCommandHistoryWeight(commandId, DateTimeOffset.UtcNow);
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsModel.cs
@@ -52,6 +52,10 @@ public record SettingsModel
 
     public bool ShowQuickAccessShelf { get; init; }
 
+    public bool ShowRecentCommandsInQuickAccessShelf { get; init; }
+
+    public HomeRecentCommandsPlacement RecentCommandsOnHome { get; init; }
+
     // When compact mode is on and the palette is centered on launch, this is the relative
     // height from the bottom of the screen (as a percentage) at which the collapsed search
     // box is vertically centered. 75 places it in the upper portion of the display. Ignored
@@ -478,4 +482,11 @@ public enum EscapeKeyBehavior
     AlwaysGoBack = 1,
     AlwaysDismiss = 2,
     AlwaysHide = 3,
+}
+
+public enum HomeRecentCommandsPlacement
+{
+    Hidden = 0,
+    BeforePinned = 1,
+    AfterPinned = 2,
 }

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/SettingsViewModel.cs
@@ -160,6 +160,7 @@ public partial class SettingsViewModel : INotifyPropertyChanged,
         {
             _settingsService.UpdateSettings(s => s with { CompactMode = value });
             PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CompactMode)));
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CanConfigureQuickAccessShelf)));
         }
     }
 
@@ -169,6 +170,27 @@ public partial class SettingsViewModel : INotifyPropertyChanged,
         set
         {
             _settingsService.UpdateSettings(s => s with { ShowQuickAccessShelf = value });
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(CanConfigureQuickAccessShelf)));
+        }
+    }
+
+    public bool CanConfigureQuickAccessShelf => CompactMode && ShowQuickAccessShelf;
+
+    public bool ShowRecentCommandsInQuickAccessShelf
+    {
+        get => _settingsService.Settings.ShowRecentCommandsInQuickAccessShelf;
+        set
+        {
+            _settingsService.UpdateSettings(s => s with { ShowRecentCommandsInQuickAccessShelf = value });
+        }
+    }
+
+    public int RecentCommandsOnHomeIndex
+    {
+        get => (int)_settingsService.Settings.RecentCommandsOnHome;
+        set
+        {
+            _settingsService.UpdateSettings(s => s with { RecentCommandsOnHome = (HomeRecentCommandsPlacement)value });
         }
     }
 

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandResolver.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI.ViewModels/TopLevelCommandResolver.cs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using Microsoft.CmdPal.Ext.Apps;
+using Microsoft.CommandPalette.Extensions;
+
+namespace Microsoft.CmdPal.UI.ViewModels;
+
+internal static class TopLevelCommandResolver
+{
+    internal const int RecentCommandLimit = 5;
+
+    internal sealed record Sections<TCommand>(
+        IReadOnlyList<TCommand> Pinned,
+        IReadOnlyList<TCommand> Recent,
+        IReadOnlyList<TCommand> Regular);
+
+    internal static Sections<IListItem> Resolve(
+        IEnumerable<PinnedCommandSettings> pinnedCommands,
+        IEnumerable<string> recentCommandIds,
+        IEnumerable<TopLevelViewModel> availableCommands,
+        bool includeApps,
+        int recentCommandLimit = RecentCommandLimit,
+        bool includeRegular = true)
+    {
+        static IListItem? ResolveRecentApp(string commandId) =>
+            AllAppsCommandProvider.Page.TryGetCurrentItem(commandId, out var item) ? item : null;
+
+        Func<string, IListItem?>? additionalRecentResolver = includeApps ? ResolveRecentApp : null;
+        return Resolve<IListItem>(
+            pinnedCommands,
+            recentCommandIds,
+            availableCommands,
+            GetProviderId,
+            GetCommandId,
+            IsEligibleForHome,
+            additionalRecentResolver,
+            recentCommandLimit,
+            includeRegular);
+    }
+
+    internal static string GetProviderId(IListItem command) =>
+        command is TopLevelViewModel topLevel ? topLevel.CommandProviderId : AllAppsCommandProvider.WellKnownId;
+
+    internal static string GetCommandId(IListItem command) =>
+        command is TopLevelViewModel topLevel ? topLevel.Id : command.Command?.Id ?? string.Empty;
+
+    internal static bool IsEligibleForHome(IListItem command) =>
+        command is TopLevelViewModel topLevel
+            ? TopLevelCommandEligibility.IsEligibleForHome(topLevel)
+            : command.Command is not null && !string.IsNullOrEmpty(command.Title);
+
+    internal static Sections<TCommand> Resolve<TCommand>(
+        IEnumerable<PinnedCommandSettings> pinnedCommands,
+        IEnumerable<string> recentCommandIds,
+        IEnumerable<TCommand> availableCommands,
+        Func<TCommand, string> providerIdSelector,
+        Func<TCommand, string> commandIdSelector,
+        Func<TCommand, bool> isEligible,
+        Func<string, TCommand?>? resolveAdditionalRecentCommand = null,
+        int recentCommandLimit = RecentCommandLimit,
+        bool includeRegular = true)
+        where TCommand : class
+    {
+        var eligibleCommands = new List<TCommand>();
+        var commandsByProviderAndId = new Dictionary<(string ProviderId, string CommandId), TCommand>();
+        var commandsById = new Dictionary<string, TCommand>(StringComparer.Ordinal);
+
+        foreach (var command in availableCommands)
+        {
+            if (!isEligible(command))
+            {
+                continue;
+            }
+
+            if (includeRegular)
+            {
+                eligibleCommands.Add(command);
+            }
+
+            var providerId = providerIdSelector(command);
+            var commandId = commandIdSelector(command);
+            commandsByProviderAndId.TryAdd((providerId, commandId), command);
+            if (!string.IsNullOrEmpty(commandId))
+            {
+                commandsById.TryAdd(commandId, command);
+            }
+        }
+
+        var featuredCommandKeys = new HashSet<(string ProviderId, string CommandId)>();
+        var featuredCommandIds = new HashSet<string>(StringComparer.Ordinal);
+        var pinned = new List<TCommand>();
+        foreach (var pinnedCommand in pinnedCommands)
+        {
+            var key = (pinnedCommand.ProviderId, pinnedCommand.CommandId);
+            if (commandsByProviderAndId.TryGetValue(key, out var command) && featuredCommandKeys.Add(key))
+            {
+                pinned.Add(command);
+                if (!string.IsNullOrEmpty(pinnedCommand.CommandId))
+                {
+                    featuredCommandIds.Add(pinnedCommand.CommandId);
+                }
+            }
+        }
+
+        var recent = new List<TCommand>();
+        if (recentCommandLimit > 0)
+        {
+            foreach (var commandId in recentCommandIds)
+            {
+                if (recent.Count == recentCommandLimit)
+                {
+                    break;
+                }
+
+                if (string.IsNullOrEmpty(commandId) || featuredCommandIds.Contains(commandId))
+                {
+                    continue;
+                }
+
+                if (!commandsById.TryGetValue(commandId, out var command))
+                {
+                    command = resolveAdditionalRecentCommand?.Invoke(commandId);
+                    if (command is null || !isEligible(command))
+                    {
+                        continue;
+                    }
+                }
+
+                var key = (providerIdSelector(command), commandIdSelector(command));
+                if (featuredCommandKeys.Add(key))
+                {
+                    recent.Add(command);
+                    featuredCommandIds.Add(commandId);
+                }
+            }
+        }
+
+        IReadOnlyList<TCommand> regular = [];
+        if (includeRegular)
+        {
+            var regularCommands = new List<TCommand>(eligibleCommands.Count);
+            foreach (var command in eligibleCommands)
+            {
+                var key = (providerIdSelector(command), commandIdSelector(command));
+                if (!featuredCommandKeys.Contains(key))
+                {
+                    regularCommands.Add(command);
+                }
+            }
+
+            regular = regularCommands;
+        }
+
+        return new Sections<TCommand>(pinned, recent, regular);
+    }
+}

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml
@@ -446,36 +446,48 @@
                     </ItemsRepeater.Layout>
                     <ItemsRepeater.ItemTemplate>
                         <DataTemplate x:DataType="viewModels:QuickAccessShelfItem">
-                            <Button
+                            <Grid
                                 Width="44"
-                                Height="40"
-                                Padding="8"
-                                AccessKey="{x:Bind ShortcutDigit, Mode=OneTime}"
-                                AutomationProperties.Name="{x:Bind Command.Title, Mode=OneWay}"
-                                Click="QuickAccessShelfItem_Click"
-                                Style="{StaticResource SubtleButtonStyle}"
-                                Tag="{x:Bind}"
-                                UseSystemFocusVisuals="{StaticResource UseSystemFocusVisuals}">
-                                <ToolTipService.ToolTip>
-                                    <ToolTip>
-                                        <StackPanel Spacing="2">
-                                            <TextBlock Text="{x:Bind Command.Title, Mode=OneWay}" />
-                                            <TextBlock
-                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                                Style="{StaticResource CaptionTextBlockStyle}"
-                                                Text="{x:Bind ShortcutDigit, Mode=OneTime, Converter={StaticResource QuickAccessShortcutTextConverter}}"
-                                                Visibility="{x:Bind ShortcutDigit, Mode=OneTime, Converter={StaticResource StringNotEmptyToVisibilityConverter}}" />
-                                        </StackPanel>
-                                    </ToolTip>
-                                </ToolTipService.ToolTip>
-                                <cpcontrols:IconBox
-                                    Width="20"
-                                    Height="20"
-                                    AutomationProperties.AccessibilityView="Raw"
-                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
-                                    SourceKey="{x:Bind Command.IconViewModel, Mode=OneWay}"
-                                    SourceRequested="{x:Bind help:IconProvider.SourceRequested20}" />
-                            </Button>
+                                Height="40">
+                                <Button
+                                    Width="44"
+                                    Height="40"
+                                    Padding="8"
+                                    AccessKey="{x:Bind ShortcutDigit, Mode=OneTime}"
+                                    AutomationProperties.Name="{x:Bind Title, Mode=OneTime}"
+                                    Click="QuickAccessShelfItem_Click"
+                                    Style="{StaticResource SubtleButtonStyle}"
+                                    Tag="{x:Bind}"
+                                    UseSystemFocusVisuals="{StaticResource UseSystemFocusVisuals}">
+                                    <ToolTipService.ToolTip>
+                                        <ToolTip>
+                                            <StackPanel Spacing="2">
+                                                <TextBlock Text="{x:Bind Title, Mode=OneTime}" />
+                                                <TextBlock
+                                                    Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                    Style="{StaticResource CaptionTextBlockStyle}"
+                                                    Text="{x:Bind ShortcutDigit, Mode=OneTime, Converter={StaticResource QuickAccessShortcutTextConverter}}"
+                                                    Visibility="{x:Bind ShortcutDigit, Mode=OneTime, Converter={StaticResource StringNotEmptyToVisibilityConverter}}" />
+                                            </StackPanel>
+                                        </ToolTip>
+                                    </ToolTipService.ToolTip>
+                                    <cpcontrols:IconBox
+                                        Width="20"
+                                        Height="20"
+                                        AutomationProperties.AccessibilityView="Raw"
+                                        Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                        SourceKey="{x:Bind Icon, Mode=OneTime}"
+                                        SourceRequested="{x:Bind help:IconProvider.SourceRequested20}" />
+                                </Button>
+                                <Border
+                                    Width="1"
+                                    Height="24"
+                                    Margin="-2,0,0,0"
+                                    HorizontalAlignment="Left"
+                                    Background="{ThemeResource CmdPal.DividerStrokeColorDefaultBrush}"
+                                    IsHitTestVisible="False"
+                                    Visibility="{x:Bind help:BindTransformers.BoolToVisibility(StartsRecentSection), Mode=OneTime}" />
+                            </Grid>
                         </DataTemplate>
                     </ItemsRepeater.ItemTemplate>
                 </ItemsRepeater>

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Pages/ShellPage.xaml.cs
@@ -146,7 +146,11 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         _quickAccessShelfEnabled = settings.ShowQuickAccessShelf;
         this.ExpandedMode = !_compactMode;
 
-        QuickAccessShelf = new(App.Current.Services.GetRequiredService<TopLevelCommandManager>(), _mainTaskScheduler);
+        QuickAccessShelf = new(
+            App.Current.Services.GetRequiredService<TopLevelCommandManager>(),
+            App.Current.Services.GetRequiredService<IAppStateService>(),
+            settings.ShowQuickAccessShelf && settings.ShowRecentCommandsInQuickAccessShelf,
+            _mainTaskScheduler);
         QuickAccessShelf.PropertyChanged += QuickAccessShelf_PropertyChanged;
 
         this.InitializeComponent();
@@ -980,7 +984,7 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
     private static void InvokeQuickAccessShelfItem(QuickAccessShelfItem item)
     {
-        WeakReferenceMessenger.Default.Send(item.Command.GetPerformCommandMessage());
+        WeakReferenceMessenger.Default.Send(item.GetPerformCommandMessage());
     }
 
     private void QuickAccessShelfItemsHost_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -1004,17 +1008,22 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
 
         foreach (var item in QuickAccessShelf.OverflowItems)
         {
+            if (item.StartsRecentSection && QuickAccessOverflowFlyout.Items.Count > 0)
+            {
+                QuickAccessOverflowFlyout.Items.Add(new MenuFlyoutSeparator());
+            }
+
             var iconBox = new IconBox
             {
                 Width = 16,
                 Height = 16,
-                SourceKey = item.Command.IconViewModel,
+                SourceKey = item.Icon,
             };
             iconBox.SourceRequested += IconProvider.SourceRequested16;
 
             var menuItem = new MenuFlyoutItem
             {
-                Text = item.Command.Title,
+                Text = item.Title,
                 Tag = item,
                 Icon = new ContentIcon { Content = iconBox },
             };
@@ -1041,8 +1050,8 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         // invoke the current view model for the same command rather than the stale snapshot.
         foreach (var currentItem in QuickAccessShelf.Items)
         {
-            if (currentItem.Command.CommandProviderId == snapshotItem.Command.CommandProviderId &&
-                currentItem.Command.Id == snapshotItem.Command.Id)
+            if (currentItem.ProviderId == snapshotItem.ProviderId &&
+                currentItem.CommandId == snapshotItem.CommandId)
             {
                 InvokeQuickAccessShelfItem(currentItem);
                 return;
@@ -1204,8 +1213,11 @@ public sealed partial class ShellPage : Microsoft.UI.Xaml.Controls.Page,
         // state single-threaded regardless of which thread raises the event.
         var compactMode = args.CompactMode;
         var quickAccessShelfEnabled = args.ShowQuickAccessShelf;
+        var includeRecentCommands = args.ShowQuickAccessShelf && args.ShowRecentCommandsInQuickAccessShelf;
         this.DispatcherQueue.TryEnqueue(() =>
         {
+            QuickAccessShelf.SetIncludeRecentCommands(includeRecentCommands);
+
             var compactModeChanged = compactMode != _compactMode;
             var quickAccessShelfChanged = quickAccessShelfEnabled != _quickAccessShelfEnabled;
             if (!compactModeChanged && !quickAccessShelfChanged)

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/AppearancePage.xaml
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Settings/AppearancePage.xaml
@@ -299,6 +299,13 @@
                                     AutomationProperties.AutomationId="CmdPal_GeneralPage_QuickAccessShelf"
                                     IsOn="{x:Bind ViewModel.ShowQuickAccessShelf, Mode=TwoWay}" />
                             </controls:SettingsCard>
+                            <controls:SettingsCard
+                                x:Uid="Settings_GeneralPage_QuickAccessShelfRecentCommands_SettingsCard"
+                                IsEnabled="{x:Bind ViewModel.CanConfigureQuickAccessShelf, Mode=OneWay}">
+                                <ToggleSwitch
+                                    AutomationProperties.AutomationId="CmdPal_GeneralPage_QuickAccessShelfRecentCommands"
+                                    IsOn="{x:Bind ViewModel.ShowRecentCommandsInQuickAccessShelf, Mode=TwoWay}" />
+                            </controls:SettingsCard>
                             <controls:SettingsCard x:Uid="Settings_GeneralPage_CompactCenterHeight_SettingsCard" IsEnabled="{x:Bind ViewModel.CompactMode, Mode=OneWay}">
                                 <Slider
                                     MinWidth="{StaticResource SettingActionControlMinWidth}"
@@ -313,6 +320,19 @@
                             </controls:SettingsCard>
                         </controls:SettingsExpander.Items>
                     </controls:SettingsExpander>
+
+                    <controls:SettingsCard
+                        x:Uid="Settings_GeneralPage_HomeRecentCommands_SettingsCard"
+                        HeaderIcon="{ui:FontIcon Glyph=&#xE81C;}">
+                        <ComboBox
+                            MinWidth="{StaticResource SettingActionControlMinWidth}"
+                            AutomationProperties.AutomationId="CmdPal_GeneralPage_HomeRecentCommands"
+                            SelectedIndex="{x:Bind ViewModel.RecentCommandsOnHomeIndex, Mode=TwoWay}">
+                            <ComboBoxItem x:Uid="Settings_GeneralPage_HomeRecentCommands_Hidden" />
+                            <ComboBoxItem x:Uid="Settings_GeneralPage_HomeRecentCommands_BeforePinned" />
+                            <ComboBoxItem x:Uid="Settings_GeneralPage_HomeRecentCommands_AfterPinned" />
+                        </ComboBox>
+                    </controls:SettingsCard>
 
                     <controls:SettingsCard x:Uid="Run_PositionHeader" HeaderIcon="{ui:FontIcon Glyph=&#xe78b;}">
                         <ComboBox

--- a/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
+++ b/src/modules/cmdpal/Microsoft.CmdPal.UI/Strings/en-us/Resources.resw
@@ -413,7 +413,28 @@ Right-click to remove the key combination, thereby deactivating the shortcut.</v
     <value>Quick access shelf</value>
   </data>
   <data name="Settings_GeneralPage_QuickAccessShelf_SettingsCard.Description" xml:space="preserve">
-    <value>Shows pinned home commands below the search box while compact mode is collapsed. Use Alt+1 through Alt+9 for the first nine visible commands and Alt+0 for overflow.</value>
+    <value>Shows pinned home commands below the search box while compact mode is collapsed. Use Alt+1 through Alt+9 for the first nine visible pinned commands and Alt+0 for overflow.</value>
+  </data>
+  <data name="Settings_GeneralPage_QuickAccessShelfRecentCommands_SettingsCard.Header" xml:space="preserve">
+    <value>Include recent commands</value>
+  </data>
+  <data name="Settings_GeneralPage_QuickAccessShelfRecentCommands_SettingsCard.Description" xml:space="preserve">
+    <value>Adds up to five recently used home commands after pinned commands on the quick access shelf.</value>
+  </data>
+  <data name="Settings_GeneralPage_HomeRecentCommands_SettingsCard.Header" xml:space="preserve">
+    <value>Recent commands on Home</value>
+  </data>
+  <data name="Settings_GeneralPage_HomeRecentCommands_SettingsCard.Description" xml:space="preserve">
+    <value>Show up to five recently used commands before or after the Pinned section.</value>
+  </data>
+  <data name="Settings_GeneralPage_HomeRecentCommands_Hidden.Content" xml:space="preserve">
+    <value>Don't show</value>
+  </data>
+  <data name="Settings_GeneralPage_HomeRecentCommands_BeforePinned.Content" xml:space="preserve">
+    <value>Before pinned</value>
+  </data>
+  <data name="Settings_GeneralPage_HomeRecentCommands_AfterPinned.Content" xml:space="preserve">
+    <value>After pinned</value>
   </data>
   <data name="QuickAccessShelfSurface.[using:Microsoft.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Quick access</value>

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Apps.UnitTests/AllAppsPageTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.Ext.Apps.UnitTests/AllAppsPageTests.cs
@@ -76,6 +76,22 @@ public class AllAppsPageTests : AppsTestBase
     }
 
     [TestMethod]
+    public async Task AllAppsPage_TryGetCurrentItemUsesPublishedCatalogWithoutReloading()
+    {
+        var mockCache = new MockAppCache();
+        mockCache.AddWin32Program(TestDataHelper.CreateTestWin32Program("Notepad", "C:\\Windows\\System32\\notepad.exe"));
+        var page = new AllAppsPage(mockCache);
+        await Task.Delay(100);
+
+        var expected = page.GetItems().OfType<AppListItem>().Single();
+
+        Assert.IsTrue(page.TryGetCurrentItem(expected.Command.Id, out var actual));
+        Assert.AreSame(expected, actual);
+        Assert.IsFalse(page.TryGetCurrentItem("missing", out var missing));
+        Assert.IsNull(missing);
+    }
+
+    [TestMethod]
     public async Task AllAppsPage_GetItems_HidesSubtitlesWhenSettingEnabled()
     {
         // Arrange

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/QuickAccessShelfResolverTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/QuickAccessShelfResolverTests.cs
@@ -2,7 +2,7 @@
 // The Microsoft Corporation licenses this file to you under the MIT license.
 // See the LICENSE file in the project root for more information.
 
-using System.Linq;
+using Microsoft.CommandPalette.Extensions.Toolkit;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
@@ -10,43 +10,6 @@ namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
 [TestClass]
 public class QuickAccessShelfResolverTests
 {
-    [TestMethod]
-    public void Resolve_UsesPinOrderAndSkipsUnavailableOrIneligibleCommands()
-    {
-        var pins = new[]
-        {
-            new PinnedCommandSettings("provider-b", "second"),
-            new PinnedCommandSettings("missing", "command"),
-            new PinnedCommandSettings("provider-a", "first"),
-            new PinnedCommandSettings("provider-a", "hidden"),
-        };
-        var commands = new[]
-        {
-            new TestCommand("provider-a", "first", IsEligible: true),
-            new TestCommand("provider-a", "hidden", IsEligible: false),
-            new TestCommand("provider-b", "second", IsEligible: true),
-        };
-
-        var resolved = QuickAccessShelfResolver.Resolve(
-            pins,
-            commands,
-            static command => command.ProviderId,
-            static command => command.CommandId,
-            static command => command.IsEligible);
-
-        CollectionAssert.AreEqual(new[] { commands[2], commands[0] }, resolved.ToArray());
-    }
-
-    [DataTestMethod]
-    [DataRow(false, "Command", true)]
-    [DataRow(true, "Command", false)]
-    [DataRow(false, "", false)]
-    [DataRow(false, null, false)]
-    public void IsEligibleForHome_ExcludesFallbacksAndUntitledCommands(bool isFallback, string? title, bool expected)
-    {
-        Assert.AreEqual(expected, TopLevelCommandEligibility.IsEligibleForHome(isFallback, title));
-    }
-
     [DataTestMethod]
     [DataRow(0, "1")]
     [DataRow(8, "9")]
@@ -55,6 +18,18 @@ public class QuickAccessShelfResolverTests
     public void IndexToShortcutDigit_MapsFirstNineItems(int index, string expectedDigit)
     {
         Assert.AreEqual(expectedDigit, QuickAccessShelfResolver.IndexToShortcutDigit(index));
+    }
+
+    [TestMethod]
+    public void RecentItemsDoNotReceiveMruDependentAccessKeys()
+    {
+        var item = new ListItem { Title = "Recent" };
+
+        var pinned = new QuickAccessShelfItem(item, shortcutIndex: 2, startsRecentSection: false);
+        var recent = new QuickAccessShelfItem(item, shortcutIndex: -1, startsRecentSection: true);
+
+        Assert.AreEqual("3", pinned.ShortcutDigit);
+        Assert.AreEqual(string.Empty, recent.ShortcutDigit);
     }
 
     [DataTestMethod]
@@ -74,6 +49,4 @@ public class QuickAccessShelfResolverTests
             expectedCapacity,
             QuickAccessShelfResolver.CalculateVisibleCapacity(itemCount, availableWidth, itemWidth: 44, spacing: 4));
     }
-
-    private sealed record TestCommand(string ProviderId, string CommandId, bool IsEligible);
 }

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/RecentCommandsTests.cs
@@ -49,6 +49,18 @@ public partial class RecentCommandsTests : CommandPaletteUnitTestBase
     }
 
     [TestMethod]
+    public void RecentCommandIdsAreMostRecentFirstAndCanBeBoundedByConsumer()
+    {
+        var history = CreateHistory(["oldest", "middle", "newest"]);
+        string[] expected = ["newest", "middle"];
+
+        CollectionAssert.AreEqual(
+            expected,
+            history.EnumerateRecentCommandIds().Take(2).ToArray());
+        Assert.AreEqual(3, history.EnumerateRecentCommandIds().Count());
+    }
+
+    [TestMethod]
     public void ValidateHistoryWeighting()
     {
         // Build history with explicit, strictly-increasing timestamps so time-decay is

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/SettingsServiceTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/SettingsServiceTests.cs
@@ -100,18 +100,27 @@ public class SettingsServiceTests
 
         Assert.IsNotNull(settings);
         Assert.IsFalse(settings.ShowQuickAccessShelf);
+        Assert.IsFalse(settings.ShowRecentCommandsInQuickAccessShelf);
+        Assert.AreEqual(HomeRecentCommandsPlacement.Hidden, settings.RecentCommandsOnHome);
     }
 
     [TestMethod]
     public void QuickAccessShelf_ExplicitValueRoundTrips()
     {
-        var source = CreateMinimalSettingsModel() with { ShowQuickAccessShelf = true };
+        var source = CreateMinimalSettingsModel() with
+        {
+            ShowQuickAccessShelf = true,
+            ShowRecentCommandsInQuickAccessShelf = true,
+            RecentCommandsOnHome = HomeRecentCommandsPlacement.BeforePinned,
+        };
 
         var json = System.Text.Json.JsonSerializer.Serialize(source, JsonSerializationContext.Default.SettingsModel);
         var settings = System.Text.Json.JsonSerializer.Deserialize(json, JsonSerializationContext.Default.SettingsModel);
 
         Assert.IsNotNull(settings);
         Assert.IsTrue(settings.ShowQuickAccessShelf);
+        Assert.IsTrue(settings.ShowRecentCommandsInQuickAccessShelf);
+        Assert.AreEqual(HomeRecentCommandsPlacement.BeforePinned, settings.RecentCommandsOnHome);
     }
 
     [TestMethod]

--- a/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/TopLevelCommandResolverTests.cs
+++ b/src/modules/cmdpal/Tests/Microsoft.CmdPal.UI.ViewModels.UnitTests/TopLevelCommandResolverTests.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation
+// The Microsoft Corporation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CmdPal.UI.ViewModels.UnitTests;
+
+[TestClass]
+public class TopLevelCommandResolverTests
+{
+    [TestMethod]
+    public void Resolve_UsesPinOrderAndSkipsUnavailableOrIneligibleCommands()
+    {
+        var pins = new[]
+        {
+            new PinnedCommandSettings("provider-b", "second"),
+            new PinnedCommandSettings("missing", "command"),
+            new PinnedCommandSettings("provider-a", "first"),
+            new PinnedCommandSettings("provider-a", "hidden"),
+        };
+        var commands = new[]
+        {
+            new TestCommand("provider-a", "first", IsEligible: true),
+            new TestCommand("provider-a", "hidden", IsEligible: false),
+            new TestCommand("provider-b", "second", IsEligible: true),
+        };
+
+        var sections = TopLevelCommandResolver.Resolve(
+            pins,
+            [],
+            commands,
+            static command => command.ProviderId,
+            static command => command.CommandId,
+            static command => command.IsEligible);
+
+        CollectionAssert.AreEqual(new[] { commands[2], commands[0] }, sections.Pinned.ToArray());
+        Assert.AreEqual(0, sections.Recent.Count);
+        Assert.AreEqual(0, sections.Regular.Count);
+    }
+
+    [TestMethod]
+    public void Resolve_RecentCommandsFollowHistoryAndExcludePinsAndMissingCommands()
+    {
+        var commands = new[]
+        {
+            new TestCommand("provider-e", "pinned", IsEligible: true),
+            new TestCommand("provider-a", "pinned", IsEligible: true),
+            new TestCommand("provider-b", "older", IsEligible: true),
+            new TestCommand("provider-c", "newer", IsEligible: true),
+            new TestCommand("provider-d", "regular", IsEligible: true),
+        };
+
+        var sections = TopLevelCommandResolver.Resolve(
+            [new PinnedCommandSettings("provider-a", "pinned")],
+            ["pinned", "missing", "newer", "older", "regular"],
+            commands,
+            static command => command.ProviderId,
+            static command => command.CommandId,
+            static command => command.IsEligible,
+            recentCommandLimit: 2);
+
+        CollectionAssert.AreEqual(new[] { commands[1] }, sections.Pinned.ToArray());
+        CollectionAssert.AreEqual(new[] { commands[3], commands[2] }, sections.Recent.ToArray());
+        CollectionAssert.AreEqual(new[] { commands[0], commands[4] }, sections.Regular.ToArray());
+    }
+
+    [TestMethod]
+    public void Resolve_UsesAdditionalResolverForRecentItemsWithoutAddingThemToRegularCommands()
+    {
+        var regular = new TestCommand("provider-a", "regular", IsEligible: true);
+        var recentApp = new TestCommand("AllApps", "recent-app", IsEligible: true);
+
+        var sections = TopLevelCommandResolver.Resolve(
+            [],
+            ["missing", "recent-app"],
+            [regular],
+            static command => command.ProviderId,
+            static command => command.CommandId,
+            static command => command.IsEligible,
+            commandId => commandId == recentApp.CommandId ? recentApp : null);
+
+        CollectionAssert.AreEqual(new[] { recentApp }, sections.Recent.ToArray());
+        CollectionAssert.AreEqual(new[] { regular }, sections.Regular.ToArray());
+    }
+
+    [DataTestMethod]
+    [DataRow(false, "Command", true)]
+    [DataRow(true, "Command", false)]
+    [DataRow(false, "", false)]
+    [DataRow(false, null, false)]
+    public void IsEligibleForHome_ExcludesFallbacksAndUntitledCommands(bool isFallback, string? title, bool expected)
+    {
+        Assert.AreEqual(expected, TopLevelCommandEligibility.IsEligibleForHome(isFallback, title));
+    }
+
+    private sealed record TestCommand(string ProviderId, string CommandId, bool IsEligible);
+}

--- a/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
+++ b/src/modules/cmdpal/ext/Microsoft.CmdPal.Ext.Apps/AllAppsPage.cs
@@ -20,7 +20,7 @@ public sealed partial class AllAppsPage : ListPage
     private readonly Lock _listLock = new();
     private readonly IAppCache _appCache;
 
-    private AppListItem[] allAppListItems = [];
+    private volatile AppListSnapshot _snapshot = AppListSnapshot.Empty;
 
     public AllAppsPage()
         : this(AppCache.Instance.Value)
@@ -50,12 +50,26 @@ public sealed partial class AllAppsPage : ListPage
         // Build or update the list if needed
         BuildListItems();
 
-        return allAppListItems;
+        return _snapshot.Items;
+    }
+
+    /// <summary>
+    /// Looks up an item in the most recently published app catalog without waiting for a reload.
+    /// </summary>
+    public bool TryGetCurrentItem(string commandId, out AppListItem? item)
+    {
+        if (string.IsNullOrEmpty(commandId))
+        {
+            item = null;
+            return false;
+        }
+
+        return _snapshot.ItemsByCommandId.TryGetValue(commandId, out item);
     }
 
     private void BuildListItems()
     {
-        if (allAppListItems.Length == 0 || _appCache.ShouldReload())
+        if (_snapshot.Items.Length == 0 || _appCache.ShouldReload())
         {
             lock (_listLock)
             {
@@ -64,7 +78,18 @@ public sealed partial class AllAppsPage : ListPage
                 Stopwatch stopwatch = new();
                 stopwatch.Start();
 
-                this.allAppListItems = GetPrograms();
+                var items = GetPrograms();
+                var itemsByCommandId = new Dictionary<string, AppListItem>(items.Length, StringComparer.Ordinal);
+                foreach (var item in items)
+                {
+                    var commandId = item.Command?.Id;
+                    if (!string.IsNullOrEmpty(commandId))
+                    {
+                        itemsByCommandId.TryAdd(commandId, item);
+                    }
+                }
+
+                _snapshot = new AppListSnapshot(items, itemsByCommandId);
 
                 this.IsLoading = false;
 
@@ -107,5 +132,12 @@ public sealed partial class AllAppsPage : ListPage
         }
 
         return [.. items];
+    }
+
+    private sealed record AppListSnapshot(
+        AppListItem[] Items,
+        IReadOnlyDictionary<string, AppListItem> ItemsByCommandId)
+    {
+        public static AppListSnapshot Empty { get; } = new([], new Dictionary<string, AppListItem>(StringComparer.Ordinal));
     }
 }


### PR DESCRIPTION
## Summary of the Pull Request

This PR adds support for recent commands on the home page and in the quick access shelf.

- Adds a configurable Recent section before or after Pinned on Home.
- Optionally appends up to five unpinned recent commands and apps to the compact shelf.
- Keeps Alt access keys stable for pinned items and separate recent shelf items visually.
- Shares command resolution and use non-blocking app catalog snapshots.
- Adds localized settings and coverage for history, resolution, persistence, and app lookup.


<!-- Please review the items on the PR checklist before submitting-->
## PR Checklist

- [x] Closes: #49910
<!--  - [ ] Closes: #yyy (add separate lines for additional resolved issues) -->
- [ ] **Communication:** I've discussed this with core contributors already. If the work hasn't been agreed, this work might be rejected
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end-user-facing strings can be localized
- [ ] **Dev docs:** Added/updated
- [ ] **New binaries:** Added on the required places
   - [ ] [JSON for signing](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ESRPSigning_core.json) for new binaries
   - [ ] [WXS for installer](https://github.com/microsoft/PowerToys/blob/main/installer/PowerToysSetup/Product.wxs) for new binaries and localization folder
   - [ ] [YML for CI pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/ci/templates/build-powertoys-steps.yml) for new test projects
   - [ ] [YML for signed pipeline](https://github.com/microsoft/PowerToys/blob/main/.pipelines/release.yml)
- [ ] **Documentation updated:** If checked, please file a pull request on [our docs repo](https://github.com/MicrosoftDocs/windows-uwp/tree/docs/hub/powertoys) and link it here: #xxx

<!-- Provide a more detailed description of the PR, other things fixed, or any additional comments/features here -->
## Detailed Description of the Pull Request / Additional comments

<!-- Describe how you validated the behavior. Add automated tests wherever possible, but list manual validation steps taken as well -->
## Validation Steps Performed

